### PR TITLE
Requests view

### DIFF
--- a/app/views/users/requests.erb
+++ b/app/views/users/requests.erb
@@ -7,7 +7,7 @@
 	<ul id='renter_bookings'>
 		<% @renter_bookings.each do |booking| %>
 			<li>
-				<%= booking.listing.name %>
+				<a href='/listings/<%= booking.listing.id %>'><%= booking.listing.name %></a>
 			</li>
 		<% end %>
 	</ul>

--- a/app/views/users/requests.erb
+++ b/app/views/users/requests.erb
@@ -8,6 +8,10 @@
 		<% @renter_bookings.each do |booking| %>
 			<li>
 				<a href='/listings/<%= booking.listing.id %>'><%= booking.listing.name %></a>
+				<br>
+				Requested from: <%= booking.book_from %>
+				<br>
+				Requested until: <%= booking.book_to %>
 			</li>
 		<% end %>
 	</ul>
@@ -18,6 +22,10 @@
 		<% @owner_bookings.each do |booking| %>
 			<li>
 				<%= booking.listing.name %>, Requested by: <%= booking.user.name %>
+				<br>
+				Requested from: <%= booking.book_from %>
+				<br>
+				Requested until: <%= booking.book_to %>
 				<br>
 				<% if booking.status == "accepted" %>
 				Booking has been accepted.

--- a/spec/features/viewing_requests_spec.rb
+++ b/spec/features/viewing_requests_spec.rb
@@ -9,6 +9,8 @@ include WebHelpers
 	    scenario "user can view the requests they have made" do
 	    	make_request
 	    	expect(page).to have_content("Peacock Paradise Private Villa")
+	    	expect(page).to have_content("Requested from: 2016-01-03")
+	    	expect(page).to have_content("Requested until: 2016-01-07")
 	    end
 
 	    scenario "user can view listing details of a property they have requested" do
@@ -28,6 +30,15 @@ include WebHelpers
 			visit '/users/requests'
 			expect(page).to have_content("Peacock Paradise Private Villa")
 			expect(page).to have_content("Requested by: Sam")
+		end
+
+		scenario "owner can see when their property has been requested from and until" do
+			make_request
+			log_out
+			log_in_owner
+			visit '/users/requests'
+			expect(page).to have_content("Requested from: 2016-01-03")
+	    	expect(page).to have_content("Requested until: 2016-01-07")
 		end
 
 	end

--- a/spec/features/viewing_requests_spec.rb
+++ b/spec/features/viewing_requests_spec.rb
@@ -10,6 +10,13 @@ include WebHelpers
 	    	make_request
 	    	expect(page).to have_content("Peacock Paradise Private Villa")
 	    end
+
+	    scenario "user can view listing details of a property they have requested" do
+	    	make_request
+	    	click_link("Peacock Paradise Private Villa")
+	    	expect(page).to have_content("My home has peacocks and a pool.")
+	    end
+
 	end
 
 	describe "owner requests" do


### PR DESCRIPTION
Users can see the dates that they have requested a property from and until.
Users can see the dates that their property has been requested.
Users can click on their requests to view the listing details.